### PR TITLE
Enable VPS log export and fix systemd screen service

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                         <div class="flex gap-2">
                             <button id="open-screen-console-btn" class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-lg text-sm">Abrir consola</button>
                             <button id="export-screen-log-btn-main" class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-lg text-sm">Descargar screen.log (Consola de Minecraft)</button>
-                            <button id="export-latest-log-btn" class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-lg text-sm">Descargar latest.log</button>
+                            <button id="export-vps-log-btn" class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-lg text-sm">Descargar log de VPS</button>
                         </div>
                     </div>
                     <div id="log-console" class="log-console bg-black rounded-lg p-4 font-mono text-sm text-green-400 overflow-y-auto whitespace-pre-wrap flex-grow"></div>

--- a/script.js
+++ b/script.js
@@ -68,7 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const createBackupBtn = document.getElementById('create-backup-btn');
     const backupOutput = document.getElementById('backup-output');
     const backupsList = document.getElementById('backups-list');
-    const exportLatestLogBtn = document.getElementById('export-latest-log-btn');
+    const exportVpsLogBtn = document.getElementById('export-vps-log-btn');
     const openScreenConsoleBtn = document.getElementById('open-screen-console-btn');
     const exportScreenLogBtnMain = document.getElementById('export-screen-log-btn-main');
     const screenConsoleModal = document.getElementById('screen-console-modal');
@@ -366,12 +366,12 @@ document.addEventListener('DOMContentLoaded', () => {
         URL.revokeObjectURL(url); a.remove();
     }
     function exportSessionLog() { downloadFile(`status-log-${new Date().toISOString()}.txt`, state.lastStatusOutput); }
-    async function exportLatestLog() {
+    async function exportVpsLog() {
         if (!state.connectionId) return;
         try {
-            const res = await fetch(`/api/get-latest-log?connectionId=${state.connectionId}`);
+            const res = await fetch(`/api/get-vps-log?connectionId=${state.connectionId}`);
             const data = await res.json();
-            downloadFile('latest.log', data.logContent || '');
+            downloadFile('vps.log', data.logContent || '');
         } catch (error) { showModal('Error', `<p class="text-red-400">${error.message}</p>`); }
     }
     async function exportScreenLog() {
@@ -383,7 +383,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) { showModal('Error', `<p class="text-red-400">${error.message}</p>`); }
     }
 
-    exportLatestLogBtn.addEventListener('click', exportLatestLog);
+    exportVpsLogBtn.addEventListener('click', exportVpsLog);
     exportScreenLogBtnMain.addEventListener('click', exportScreenLog);
     openScreenConsoleBtn.addEventListener('click', () => { screenConsoleLog.textContent=''; openScreenConsole(); });
     screenConsoleCloseBtn.addEventListener('click', closeScreenConsole);


### PR DESCRIPTION
## Summary
- Expose VPS system logs via new API and UI download button
- Update install script and systemd unit for a persistent screen session
- Redirect install output solely to `/home/USER/install.log`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b04e43c0833086cda9427e9f016b