### PR TITLE
Fix service monitoring and frontend command handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -196,6 +196,7 @@ cat << _SERVICE > minecraft.service.tmp
 [Unit]
 Description=Minecraft Server (${serverType} ${mcVersion})
 After=network.target
+
 [Service]
 User=${sshData.sshUser}
 Nice=1
@@ -203,9 +204,11 @@ KillMode=control-group
 SuccessExitStatus=0 1
 WorkingDirectory=$SERVER_DIR
 Type=forking
+PIDFile=/run/minecraft.pid
 RemainAfterExit=yes
-ExecStart=/usr/bin/screen -dmS minecraft -L -Logfile $SERVER_DIR/screen.log /bin/bash $SERVER_DIR/start.sh
-ExecStop=/usr/bin/screen -S minecraft -p 0 -X eval "stuff \"stop\\015\""
+ExecStart=/bin/bash -c '/usr/bin/screen -dmS minecraft -L -Logfile $SERVER_DIR/screen.log /bin/bash $SERVER_DIR/start.sh; sleep 1; screen -list | grep "\\.minecraft" | head -n1 | cut -d. -f1 | tr -d "\\t" > /run/minecraft.pid'
+ExecStop=/bin/bash -c '/usr/bin/screen -S minecraft -p 0 -X eval "stuff \\"stop\\015\""; sleep 5; /usr/bin/screen -S minecraft -X quit'
+
 [Install]
 WantedBy=multi-user.target
 _SERVICE


### PR DESCRIPTION
## Summary
- Ensure systemd service tracks the Minecraft screen session via PIDFile and proper start/stop scripts
- Improve console command routing and feedback in the UI
- Detect installation success reliably and show active server banner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9bdb5af488330b8b9685eea4ec30c