### PR TITLE
Enable RAM tuning and stabilize service and console handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,16 @@
                                 <option>Cargando versiones...</option>
                             </select>
                         </div>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div>
+                                <label for="min-ram" class="block mb-2 text-sm font-medium text-gray-300">RAM mínima (Xms)</label>
+                                <input type="text" id="min-ram" value="4G" class="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white" />
+                            </div>
+                            <div>
+                                <label for="max-ram" class="block mb-2 text-sm font-medium text-gray-300">RAM máxima (Xmx)</label>
+                                <input type="text" id="max-ram" value="8G" class="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white" />
+                            </div>
+                        </div>
                         <div class="pt-4 border-t border-gray-700">
                             <h4 class="text-lg font-bold mb-3 text-gray-200">Propiedades del Servidor</h4>
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-64 overflow-y-auto p-2 bg-gray-900/50 rounded-lg">

--- a/script.js
+++ b/script.js
@@ -45,6 +45,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const installerCloseBtn = document.getElementById('installer-close-btn');
     const serverTypeSelect = document.getElementById('server-type');
     const minecraftVersionSelect = document.getElementById('minecraft-version');
+    const minRamInput = document.getElementById('min-ram');
+    const maxRamInput = document.getElementById('max-ram');
     const installerOutput = document.getElementById('installer-output');
     const installServerBtn = document.getElementById('install-server-btn');
     const commandInput = document.getElementById('command-input');
@@ -101,6 +103,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const serverType = serverTypeSelect.value;
         const mcVersion = minecraftVersionSelect.value;
         const properties = collectInstallerProperties();
+        const minRam = minRamInput.value.trim();
+        const maxRam = maxRamInput.value.trim();
         if (!serverType || !mcVersion) { installerOutput.textContent = 'Debe seleccionar tipo y versión.'; return; }
         installerOutput.textContent = '';
         installServerBtn.disabled = true;
@@ -108,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const res = await fetch('/api/install-server', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ connectionId: state.connectionId, serverType, mcVersion, properties })
+                body: JSON.stringify({ connectionId: state.connectionId, serverType, mcVersion, properties, minRam, maxRam })
             });
             const reader = res.body.getReader();
             const decoder = new TextDecoder();
@@ -236,6 +240,8 @@ document.addEventListener('DOMContentLoaded', () => {
               await populateVersionDropdowns();
               modsGuideBtn.classList.toggle('hidden', serverTypeSelect.value !== 'fabric');
               if (cfg.mcVersion) minecraftVersionSelect.value = cfg.mcVersion;
+              minRamInput.value = cfg.minRam || '4G';
+              maxRamInput.value = cfg.maxRam || '8G';
               Object.entries(cfg.properties || {}).forEach(([k, v]) => {
                   const el = document.getElementById(`prop-${k}`);
                   if (el) el.value = v;
@@ -246,6 +252,8 @@ document.addEventListener('DOMContentLoaded', () => {
           const preset = {
               serverType: serverTypeSelect.value,
               mcVersion: minecraftVersionSelect.value,
+              minRam: minRamInput.value.trim(),
+              maxRam: maxRamInput.value.trim(),
               properties: collectInstallerProperties()
           };
           downloadFile('server-preset.json', JSON.stringify(preset, null, 2));


### PR DESCRIPTION
## Summary
- allow specifying min and max RAM during installation and use them in generated start script
- use Type=forking systemd unit with screen for persistent server process
- ensure console commands send newline and presets store RAM values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d9a075e883308c63f1c18d799b96