### PR TITLE
Fix systemd service, clean logs and add file explorer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,14 @@ npm start
 
 El servidor Express quedará escuchando en `http://localhost:3000`. Abre `index.html` en tu navegador para usar la interfaz.
 
+### Permiso para reiniciar la VPS
+
+Para que el botón **Reiniciar VPS** funcione, el usuario que ejecuta la aplicación debe tener permisos para ejecutar `/sbin/reboot` sin contraseña. Añade un archivo en `/etc/sudoers.d/` con la siguiente línea (sustituye `ubuntu` por tu usuario si es distinto):
+
+```bash
+ubuntu ALL=(ALL) NOPASSWD: /sbin/reboot
+```
+
 ### Instalación desde cero en Windows
 
 1. Instala [Git](https://git-scm.com/download/win) y [Node.js](https://nodejs.org/) (incluye npm).

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                             <button id="edit-properties-btn" class="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg">Editar server.properties</button>
                             <button id="manage-players-btn" class="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg">Gestionar Jugadores</button>
                             <button id="manage-backups-btn" class="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg">Sistema de Copias</button>
+                            <button id="file-explorer-btn" class="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg">Explorador de Archivos</button>
                         </div>
                     </div>
                     <div>
@@ -306,6 +307,16 @@
                 <h4 class="text-lg font-bold mb-3">Copias Disponibles</h4>
                 <ul id="backups-list" class="bg-gray-900/50 rounded-lg p-2"></ul>
             </div>
+        </div>
+    </div>
+
+    <div id="file-explorer-modal" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-80 hidden">
+        <div class="bg-gray-800 rounded-2xl shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+            <div class="flex justify-between items-center p-5 border-b border-gray-700">
+                <h3 class="text-2xl font-bold text-white">Explorador de Archivos</h3>
+                <button id="file-explorer-close-btn" class="text-gray-400 hover:text-white text-3xl leading-none">&times;</button>
+            </div>
+            <div id="file-explorer-body" class="flex-grow p-6 overflow-y-auto"></div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- stabilize minecraft systemd service with forking type and safer stop logic
- filter server logs and document passwordless reboot
- add in-app file explorer for inspecting server files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e10428cc83308b7b0edf523129de