### PR TITLE
fix: ensure screen usage and refine console UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,11 +109,6 @@
                         </div>
                     </div>
                     <div id="vps-console" class="log-console bg-black rounded-lg p-4 font-mono text-sm text-green-400 overflow-y-auto whitespace-pre-wrap flex-grow"></div>
-                    <div class="mt-4">
-                        <select id="command-dropdown" class="w-full bg-gray-700 border border-gray-600 rounded-lg px-4 py-2 text-white">
-                            <option value="">Comandos comunes</option>
-                        </select>
-                    </div>
                     <div class="mt-6 flex items-center justify-between">
                         <button id="disconnect-btn" class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-6 rounded-lg">Desconectar</button>
                         <button id="export-config-btn" class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg transition duration-300 text-sm">Exportar Configuración Actual</button>
@@ -336,12 +331,18 @@
     </div>
 
     <div id="mc-console-modal" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-80 hidden">
-        <div class="bg-gray-800 rounded-2xl shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+        <div class="bg-gray-800 rounded-2xl shadow-xl w-full max-w-5xl max-h-[90vh] flex flex-col">
             <div class="flex justify-between items-center p-5 border-b border-gray-700">
                 <h3 class="text-2xl font-bold text-white">Consola de Minecraft</h3>
                 <button id="mc-console-close-btn" class="text-gray-400 hover:text-white text-3xl leading-none">&times;</button>
             </div>
-            <div id="mc-console" class="bg-black p-4 font-mono text-sm text-green-400 flex-grow overflow-y-auto"></div>
+            <div class="flex flex-grow overflow-hidden">
+                <div id="mc-console" class="bg-black p-4 font-mono text-sm text-green-400 flex-grow overflow-y-auto"></div>
+                <div class="w-64 bg-gray-900 border-l border-gray-700 p-4 overflow-y-auto">
+                    <h4 class="text-lg font-semibold text-white mb-2">Comandos comunes</h4>
+                    <ul id="mc-command-list" class="space-y-2 text-sm"></ul>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ set -e
 MINECRAFT_USER="minecraft"
 MINECRAFT_GROUP="minecraft"
 SERVER_DIR="/opt/minecraft/server"
+MAX_RAM="8G"
+MIN_RAM="4G"
 
 echo "Paso 1/6: Creando usuario y grupo..."
 if id -u "$MINECRAFT_USER" &>/dev/null; then
@@ -64,6 +66,8 @@ fi
 
 sed -e "s/{{USER}}/${MINECRAFT_USER}/g" \
     -e "s|{{WORKING_DIR}}|${SERVER_DIR}|g" \
+    -e "s/{{MAX_RAM}}/${MAX_RAM}/g" \
+    -e "s/{{MIN_RAM}}/${MIN_RAM}/g" \
     scripts/minecraft.service.template > /etc/systemd/system/minecraft.service
 
 echo "Verificando la sintaxis del archivo de servicio generado..."
@@ -76,14 +80,14 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "Recargando el daemon de systemd..."
-systemctl daemon-reload
+echo "Recargando el daemon de systemd para aplicar los cambios..."
+sudo systemctl daemon-reload
 
-echo "Habilitando el servicio minecraft para el inicio automático..."
-systemctl enable minecraft.service
+echo "Reiniciando el servicio de Minecraft para usar la nueva configuración..."
+sudo systemctl restart minecraft.service
 
-echo "Iniciando el servicio minecraft..."
-systemctl start minecraft.service
+echo "Habilitando el servicio para el inicio automático..."
+sudo systemctl enable minecraft.service
 
 echo "Instalación del servicio completada. Estado del servicio:"
-systemctl status minecraft.service --no-pager
+sudo systemctl status minecraft.service --no-pager

--- a/script.js
+++ b/script.js
@@ -34,7 +34,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportPresetBtn = document.getElementById('export-preset-btn');
     const presetFileInput = document.getElementById('preset-file-input');
     const vpsConsole = document.getElementById('vps-console');
-    const commandDropdown = document.getElementById('command-dropdown');
     const notificationArea = document.getElementById('server-status-notification');
     const cpuUsageEl = document.getElementById('cpu-usage');
     const ramUsageEl = document.getElementById('ram-usage');
@@ -83,6 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const mcConsoleModal = document.getElementById('mc-console-modal');
     const mcConsoleCloseBtn = document.getElementById('mc-console-close-btn');
     const mcConsole = document.getElementById('mc-console');
+    const mcCommandList = document.getElementById('mc-command-list');
     const onlinePlayersList = document.getElementById('online-players-list');
     const refreshOnlineBtn = document.getElementById('refresh-online-btn');
     const adminPlayerName = document.getElementById('admin-player-name');
@@ -459,19 +459,28 @@ document.addEventListener('DOMContentLoaded', () => {
         { cmd: '/gamemode survival <jugador>', desc: 'Modo supervivencia' },
         { cmd: '/gamemode creative <jugador>', desc: 'Modo creativo' }
     ];
-    commonCommands.forEach(c => {
-        const opt = document.createElement('option');
-        opt.value = c.cmd;
-        opt.textContent = `${c.cmd} - ${c.desc}`;
-        commandDropdown.appendChild(opt);
-    });
-    commandDropdown.addEventListener('change', () => {
-        const cmd = commandDropdown.value;
-        if (cmd) {
-            navigator.clipboard.writeText(cmd).then(() => alert('Copiado al portapapeles'));
-            commandDropdown.value = '';
-        }
-    });
+
+    const showToast = (message) => {
+        const toast = document.createElement('div');
+        toast.textContent = message;
+        toast.className = 'fixed bottom-4 right-4 bg-gray-700 text-white px-4 py-2 rounded shadow-lg';
+        document.body.appendChild(toast);
+        setTimeout(() => toast.remove(), 2000);
+    };
+
+    function renderCommandList() {
+        mcCommandList.innerHTML = '';
+        commonCommands.forEach(c => {
+            const li = document.createElement('li');
+            li.className = 'cursor-pointer hover:bg-gray-700 p-2 rounded';
+            li.innerHTML = `<span class="font-mono text-green-400">${c.cmd}</span> - <span class="text-gray-300">${c.desc}</span>`;
+            li.addEventListener('click', () => {
+                navigator.clipboard.writeText(c.cmd + ' ').then(() => showToast('¡Comando copiado!'));
+            });
+            mcCommandList.appendChild(li);
+        });
+    }
+    renderCommandList();
 
     function sendCommandDirect(command) {
         if (!command) return;
@@ -487,11 +496,14 @@ document.addEventListener('DOMContentLoaded', () => {
         state.vpsSocket = socket;
         const term = new Terminal({ cursorBlink: true });
         const fitAddon = new FitAddon.FitAddon();
-        const attachAddon = new AttachAddon.AttachAddon(socket);
+        const attachAddon = new AttachAddon.AttachAddon(socket, { bidirectional: true });
         term.loadAddon(fitAddon);
         term.loadAddon(attachAddon);
         term.open(vpsConsole);
         fitAddon.fit();
+        term.focus();
+        vpsConsole.addEventListener('click', () => term.focus());
+        socket.addEventListener('open', () => term.focus());
         window.addEventListener('resize', () => fitAddon.fit());
         state.vpsTerm = term;
     }
@@ -513,11 +525,14 @@ document.addEventListener('DOMContentLoaded', () => {
         state.mcSocket = socket;
         const term = new Terminal({ cursorBlink: true });
         const fitAddon = new FitAddon.FitAddon();
-        const attachAddon = new AttachAddon.AttachAddon(socket);
+        const attachAddon = new AttachAddon.AttachAddon(socket, { bidirectional: true });
         term.loadAddon(fitAddon);
         term.loadAddon(attachAddon);
         term.open(mcConsole);
         fitAddon.fit();
+        term.focus();
+        mcConsole.addEventListener('click', () => term.focus());
+        socket.addEventListener('open', () => term.focus());
         window.addEventListener('resize', () => fitAddon.fit());
         state.mcTerm = term;
     }

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -13,7 +13,7 @@ After=network-online.target
 User=$MC_USER
 Group=$MC_USER
 WorkingDirectory=$MC_DIR
-ExecStart=/usr/bin/java -Xmx$MAX_RAM -Xms$MIN_RAM -jar $JAR_NAME nogui
+ExecStart=/usr/bin/screen -S minecraft-console -d -m /usr/bin/java -Xmx$MAX_RAM -Xms$MIN_RAM -jar $JAR_NAME nogui
 Restart=on-failure
 RestartSec=30s
 StandardInput=null
@@ -33,5 +33,5 @@ if [ $? -ne 0 ]; then
 fi
 
 sudo systemctl daemon-reload
-sudo systemctl enable minecraft.service
 sudo systemctl restart minecraft.service
+sudo systemctl enable minecraft.service

--- a/scripts/minecraft.service.template
+++ b/scripts/minecraft.service.template
@@ -11,8 +11,9 @@ Group={{USER}}
 # Set the working directory to where the server files are located
 WorkingDirectory={{WORKING_DIR}}
 
-# Command to start the server. Adjust memory flags (-Xmx, -Xms) as needed.
-ExecStart=/usr/bin/screen -S minecraft-console -d -m /usr/bin/java -Xmx4G -Xms1G -jar server.jar nogui
+# Command to start the server inside a named screen session.
+# Memory values are replaced during installation.
+ExecStart=/usr/bin/screen -S minecraft-console -d -m /usr/bin/java -Xmx{{MAX_RAM}} -Xms{{MIN_RAM}} -jar server.jar nogui
 
 # Restart policy for resilience
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Run minecraft server inside a named screen session via systemd service
- Reload and restart service during installation with configurable memory limits
- Redesign VPS and Minecraft consoles with interactive terminals and a helpful command sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba32e70d948330b9789227fee20977