### PR TITLE
feat: expand file manager and vps restart confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
  * Gestión de Firewall: Automatiza la configuración de reglas de firewall tanto en la VPS (UFW) como en las Listas de Seguridad de OCI.
  * Copias de Seguridad: Crea y gestiona copias de seguridad del mundo del servidor.
  * Gestión de Jugadores: Administra la lista blanca (whitelist) y baneos de jugadores.
+ * Explorador de Archivos: Navega, descarga y gestiona archivos del VPS directamente desde la interfaz.
 * Interfaz Web Intuitiva: Controla todos los aspectos de tu servidor desde una interfaz web moderna y fácil de usar.
 ## 🗂️ Estructura del Proyecto
 ```


### PR DESCRIPTION
## Summary
- allow file explorer to access full VPS filesystem and handle delete/move/copy/rename
- add confirmation modal for VPS reboot
- document file manager in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb30295d208330aeb241a26066fd3b